### PR TITLE
When proctoring is enabled, hide the back button in secure layout

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -250,6 +250,13 @@ class quizaccess_proctor extends quiz_access_rule_base
         if ($local_proview_enabled && $quizaccess_proctor_setting_enabled && $proctortype !== 'noproctor') {
             $page->set_pagelayout('secure');
             $page->set_popup_notification_allowed(false); // Prevent message notifications.
+            $page->requires->js_amd_inline('
+                require(["jquery"], function($) {
+                    $(document).ready(function() {
+                        $(".pagelayout-secure").find("#region-main > div > div.container-fluid.tertiary-navigation > div > div > a").css("display", "none");
+                    });
+                });
+            ');
         }
 
         if ($this->is_tsb_required() && !strpos($_SERVER ['HTTP_USER_AGENT'], "Proview-SB")) {

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023120302;
+$plugin->version = 2023120801;
 $plugin->requires = 2020061500;
-$plugin->release = '1.3.0 (Build: 2023120302)';
+$plugin->release = '1.3.1 (Build: 2023120801)';
 $plugin->component = 'quizaccess_proctor';
 $plugin->maturity = MATURITY_STABLE;
 


### PR DESCRIPTION
## Description
- When proctoring is enabled, hide the back button

## Github Issue
- Resolves #38 

## Checklist before requesting a review
- [x] One line description of the changes is added in the PR

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires only a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a new visual behavior on the secure page layout to enhance user experience.

- **Documentation**
  - Updated version and release notes to reflect the latest incremental update.

- **Bug Fixes**
  - Addressed minor issues for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->