### PR TITLE
Include candidate instructions in the quiz callback payload

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -92,6 +92,7 @@ class quizaccess_proctor_observer
         $eventdata->proctoring_enabled = !($quiz_proctor_settings->proctortype == 'noproctor');
         $eventdata->proctoring_type = ($quiz_proctor_settings->proctortype == 'noproctor') ? NULL : $quiz_proctor_settings->proctortype;
         $eventdata->tsb_enabled = boolval($quiz_proctor_settings->tsbenabled);
+        $eventdata->instructions = (string)($quiz_proctor_settings->instructions ?? '');
         $eventdata->attempts = 0;
         $eventdata->timeopen = (int)$quiz->timeopen;
         $eventdata->timeclose = (int)$quiz->timeclose;


### PR DESCRIPTION
This PR proposes sending the candidate instructions configured on a quiz in the payload the plugin posts to the Proview quiz callback, so they arrive alongside the rest of the quiz configuration (Fixes #53). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/375. You can sign in with your GitHub ID to claim ownership of the project.

## What this changes

`quizaccess_proctor_observer::store()` assembles the `$eventdata` object that is posted to `<proview_callback_url>/quiz` whenever a quiz course module is created, updated or deleted — it is wired to those three `\core\event\course_module_*` events in `db/events.php`, so it runs on every quiz save. The payload carries `proctoring_type`, `tsb_enabled` and the quiz timing fields, but never `instructions`, even though that value is collected by the quiz settings form (`classes/settings_provider.php`), written to `quizaccess_proctor.instructions` by `quizaccess_proctor::save_settings()` in `rule.php`, and selected back by `get_settings_sql()`. The instructions are stored correctly in Moodle and simply never leave it, which matches what #53 describes: they are configured on the quiz but do not turn up on the Proview side.

The change is one line in `classes/observer.php`, placed with the other fields read from the plugin's own settings row:

```php
$eventdata->instructions = (string)($quiz_proctor_settings->instructions ?? '');
```

It is purely additive, so any consumer that ignores unknown keys is unaffected, and the key name matches the plugin's own field name in the form, the database column and the language string — happy to rename it if the callback endpoint expects something else. The null-coalescing guard matters for the delete path and for quizzes with no `quizaccess_proctor` row (the situation #60 is about): there `$quiz_proctor_settings` is `false`, and the guard yields an empty string instead of adding another warning to the ones lines 92-94 already emit on that path.

## How to check it

Reproduced on `master` at 7bda7eb by running the observer with Moodle's globals stubbed, which prints the JSON body that would be posted to `/quiz`:

```
$ php payload-check.php /path/to/moodle-quizaccess_proctor   # on master, 7bda7eb
payload keys: quiz_title, quiz_id, course_id, course_module_id, proctoring_enabled, proctoring_type, tsb_enabled, attempts, timeopen, timeclose, timelimit, overduehandling, graceperiod, timemodified, timecreated, userid, action
instructions: ABSENT
```

The same script on this branch:

```
$ php payload-check.php /path/to/moodle-quizaccess_proctor   # this branch
payload keys: quiz_title, quiz_id, course_id, course_module_id, proctoring_enabled, proctoring_type, tsb_enabled, instructions, attempts, timeopen, timeclose, timelimit, overduehandling, graceperiod, timemodified, timecreated, userid, action
instructions: '<p>Keep your face visible for the whole attempt.</p>'
```

Making the stub return `false` for the `quizaccess_proctor` record reproduces the missing-row case: both trees emit the same four warnings from lines 92-94, and this branch adds `instructions: ''` without a fifth one. `php -l` is clean across every tracked PHP file on both trees, and the bundled `phpcs.phar --standard=PSR12` prints an identical summary before and after — same counts, same 16 files — so the added line brings in nothing new. There is no PHPUnit setup in the repo, so the script below is the whole harness; it is self-contained and takes a couple of seconds.

<details>
<summary>payload-check.php</summary>

```php
<?php
// Prints the JSON body that quizaccess_proctor_observer::store() posts to <callback>/quiz,
// with Moodle's globals stubbed. Usage: php payload-check.php /path/to/plugin/checkout
$plugin = rtrim($argv[1], '/');
$root = sys_get_temp_dir() . '/proctor-payload-check';
is_dir("$root/lib") || mkdir("$root/lib", 0777, true);
is_dir("$root/mod/quiz/accessrule/proctor/vendor") || mkdir("$root/mod/quiz/accessrule/proctor/vendor", 0777, true);
file_put_contents("$root/mod/quiz/accessrule/proctor/vendor/autoload.php", '<?php
namespace Sentry;
function init($options) {}
function captureException(\Throwable $e) { fwrite(STDERR, "sentry: " . $e->getMessage() . PHP_EOL); }');
file_put_contents("$root/lib/filelib.php", '<?php
class curl {
    public $error = "";
    public function setHeader($headers) {}
    public function get_errno() { return 0; }
    public function post($url, $data) {
        $GLOBALS["posted"][$url] = $data;
        return "{\"access_token\":\"stub\"}";
    }
}');
file_put_contents("$root/lib/eventbase.php", '<?php
namespace core\event;
abstract class base {
    public $other = ["modulename" => "quiz", "instanceid" => 42, "name" => "Final exam"];
    public $courseid = 5;
    public $objectid = 77;
    public $userid = 3;
    public $eventname = "\\\\core\\\\event\\\\course_module_updated";
}');

define('MOODLE_INTERNAL', true);
$GLOBALS['posted'] = [];
$CFG = new stdClass();
$CFG->dirroot = $root;
$CFG->libdir = "$root/lib";
require "$root/lib/eventbase.php";

class moodle_exception extends Exception {}
function get_config($component, $name) {
    return ['enableproctor' => 1, 'proview_callback_url' => 'https://proview.example/api',
            'proview_admin_username' => 'u', 'proview_admin_password' => 'p'][$name] ?? false;
}
class stub_db {
    public function get_record($table, $conditions) {
        if ($table === 'quiz') {
            return (object)['id' => 42, 'timeopen' => 0, 'timeclose' => 0, 'timelimit' => 3600,
                'overduehandling' => 'autosubmit', 'graceperiod' => 0,
                'timemodified' => 1700000500, 'timecreated' => 1699990000];
        }
        return (object)['id' => 9, 'quizid' => 42, 'cmid' => 77, 'proctortype' => 'record_and_review',
            'tsbenabled' => 1, 'reference_link' => '',
            'instructions' => '<p>Keep your face visible for the whole attempt.</p>'];
    }
}
$DB = new stub_db();
require "$plugin/classes/observer.php";

quizaccess_proctor_observer::store(new class extends \core\event\base {});

$payload = json_decode($GLOBALS['posted']['https://proview.example/api/quiz'] ?? '{}', true);
echo "payload keys: " . implode(', ', array_keys($payload)) . "\n";
echo "instructions: " . (array_key_exists('instructions', $payload)
    ? var_export($payload['instructions'], true) : 'ABSENT') . "\n";
```

</details>

## How this was managed

This work was tracked on a board imported from this repository's own issues and pull requests (51 stories), as the story [Request to make Candidate Instruction visible in LP sessions and Database.](https://eastagiletracker.com/projects/375/stories/227170) on the board at https://eastagiletracker.com/projects/375.

![board](https://raw.githubusercontent.com/eastagiletracker/moodle-quizaccess_proctor/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
